### PR TITLE
Removed shell promt sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 
 ### Installation
 
-```
-$ pnpm install
+```Shell
+pnpm install
 ```
 
 ### Local Development
 
 clone this repository
 
-```
-$ pnpm start
+```Shell
+pnpm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -22,16 +22,16 @@ This command starts a local development server and opens up a browser window. Mo
 
 To see the docs in German you need to start it with the following command
 
-```
-$ pnpm run start --locale de
+```Shell
+pnpm run start --locale de
 ```
 
 It is not possible to switch between the languages via the language switcher
 
 ### Build
 
-```
-$ pnpm build
+```Shell
+pnpm build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -40,14 +40,14 @@ This command generates static content into the `build` directory and can be serv
 
 Using SSH:
 
-```
-$ USE_SSH=true pnpm deploy
+```Shell
+USE_SSH=true pnpm deploy
 ```
 
 Not using SSH:
 
-```
-$ GIT_USER=<Your GitHub username> pnpm deploy
+```Shell
+GIT_USER=<Your GitHub username> pnpm deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
removed the shell promt sign $ because it was copied every time you hit the copy buton in the guide. added shell syntax