### PR TITLE
Fix center position on hero bg image

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -53,6 +53,8 @@
 
 .hero {
     background-image: url("/static/img/oc-banner.jpg");
+    background-size: cover;
+    background-position: center;
 
     .button {
         width: 300px;


### PR DESCRIPTION
center + cover hero section background image

# before 👎
![screenie000190@2x](https://github.com/user-attachments/assets/47afbe1f-8426-4a59-a697-f96c0b65ea66)

# after 👍
![screenie000191@2x](https://github.com/user-attachments/assets/901c4d36-332a-4d0a-bb55-b2b2898a2fd0)
