### PR TITLE
🎉 Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## [0.2.0](https://github.com/opencloud-eu/docs/releases/tag/0.2.0) - 2025-02-28
+## [0.1.1](https://github.com/opencloud-eu/docs/releases/tag/0.1.1) - 2025-02-28
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@ScharfViktor
+@AlexAndBear, @ScharfViktor
 
-### 👷 Admin Documentation
+### 🐛 Bug Fixes
 
+- Adjust social card description [[#119](https://github.com/opencloud-eu/docs/pull/119)]
 - Fix docker images names [[#115](https://github.com/opencloud-eu/docs/pull/115)]
 
 ## [0.1.0](https://github.com/opencloud-eu/docs/releases/tag/0.1.0) - 2025-02-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.0](https://github.com/opencloud-eu/docs/releases/tag/0.2.0) - 2025-02-28
+
+### ❤️ Thanks to all contributors! ❤️
+
+@ScharfViktor
+
+### 👷 Admin Documentation
+
+- Fix docker images names [[#115](https://github.com/opencloud-eu/docs/pull/115)]
+
 ## [0.1.0](https://github.com/opencloud-eu/docs/releases/tag/0.1.0) - 2025-02-28
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.1.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.1.1](https://github.com/opencloud-eu/docs/releases/tag/0.1.1) - 2025-02-28

### 🐛 Bug Fixes

- Adjust social card description [[#119](https://github.com/opencloud-eu/docs/pull/119)]
- Fix docker images names [[#115](https://github.com/opencloud-eu/docs/pull/115)]