### PR TITLE
Start OpenCloud in detached instead of interactive mode

### DIFF
--- a/docs/admin/20-getting-started/30-docker.md
+++ b/docs/admin/20-getting-started/30-docker.md
@@ -62,7 +62,7 @@ You can set your own password using `IDM_ADMIN_PASSWORD=your_password`. If not s
 docker run \
     --name opencloud \
     --rm \
-    -it \
+    -d \
     -p 9200:9200 \
     -v $HOME/opencloud/opencloud-config:/etc/opencloud \
     -v $HOME/opencloud/opencloud-data:/var/lib/opencloud \


### PR DESCRIPTION
The code block in section [4. Start OpenCloud](https://docs.opencloud.eu/docs/admin/getting-started/docker#4-start-opencloud) starts the container in interactive mode with an allocated pseudo-tty (`-it`).

I changed it to start the container in detached (`-d`) mode, which should be the more common mode when running services, IMHO.

I appreciate it, if you accept this small contribution.