### PR TITLE
🎉 Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.6.0](https://github.com/opencloud-eu/docs/releases/tag/1.6.0) - 2025-03-17
+## [1.6.0](https://github.com/opencloud-eu/docs/releases/tag/1.6.0) - 2025-03-18
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### 👷 Admin Documentation
 
+- Refining the text in backup tutorial [[#170](https://github.com/opencloud-eu/docs/pull/170)]
 - Insert a disclaimer in Bare-Metal Tutorial [[#167](https://github.com/opencloud-eu/docs/pull/167)]
 
 ## [1.5.0](https://github.com/opencloud-eu/docs/releases/tag/1.5.0) - 2025-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.6.0](https://github.com/opencloud-eu/docs/releases/tag/1.6.0) - 2025-03-17
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Heiko-Pohl
+
+### 👷 Admin Documentation
+
+- Insert a disclaimer in Bare-Metal Tutorial [[#167](https://github.com/opencloud-eu/docs/pull/167)]
+
 ## [1.5.0](https://github.com/opencloud-eu/docs/releases/tag/1.5.0) - 2025-03-17
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.6.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.6.0](https://github.com/opencloud-eu/docs/releases/tag/1.6.0) - 2025-03-18

### 👷 Admin Documentation

- Refining the text in backup tutorial [[#170](https://github.com/opencloud-eu/docs/pull/170)]
- Insert a disclaimer in Bare-Metal Tutorial [[#167](https://github.com/opencloud-eu/docs/pull/167)]