### PR TITLE
🎉 Release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.10.1](https://github.com/opencloud-eu/docs/releases/tag/1.10.1) - 2025-04-03
+
+### ❤️ Thanks to all contributors! ❤️
+
+@AlexAndBear
+
+### 📦️ Build&Tools
+
+- Fix broken favicon on firefox [[#205](https://github.com/opencloud-eu/docs/pull/205)]
+
 ## [1.10.0](https://github.com/opencloud-eu/docs/releases/tag/1.10.0) - 2025-04-02
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [1.10.1](https://github.com/opencloud-eu/docs/releases/tag/1.10.1) - 2025-04-03
+## [1.11.0](https://github.com/opencloud-eu/docs/releases/tag/1.11.0) - 2025-04-04
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@AlexAndBear
+@AlexAndBear, @tbsbdr
+
+### 👷 Admin Documentation
+
+- Add TUS [[#208](https://github.com/opencloud-eu/docs/pull/208)]
 
 ### 📦️ Build&Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Changelog
 
-## [1.11.0](https://github.com/opencloud-eu/docs/releases/tag/1.11.0) - 2025-04-04
+## [1.11.0](https://github.com/opencloud-eu/docs/releases/tag/1.11.0) - 2025-04-07
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@AlexAndBear, @tbsbdr
+@AlexAndBear, @ScharfViktor, @tbsbdr
 
 ### 👷 Admin Documentation
 
 - Add TUS [[#208](https://github.com/opencloud-eu/docs/pull/208)]
+
+### 🐛 Bug Fixes
+
+- fix url in the bare-metal [[#211](https://github.com/opencloud-eu/docs/pull/211)]
 
 ### 📦️ Build&Tools
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.11.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.11.0](https://github.com/opencloud-eu/docs/releases/tag/1.11.0) - 2025-04-07

### 👷 Admin Documentation

- Add TUS [[#208](https://github.com/opencloud-eu/docs/pull/208)]

### 🐛 Bug Fixes

- fix url in the bare-metal [[#211](https://github.com/opencloud-eu/docs/pull/211)]

### 📦️ Build&Tools

- Fix broken favicon on firefox [[#205](https://github.com/opencloud-eu/docs/pull/205)]