### PR TITLE
fix url in the bare-metal

### DIFF
--- a/docs/admin/20-getting-started/30-other/40-bare-metal.md
+++ b/docs/admin/20-getting-started/30-other/40-bare-metal.md
@@ -92,7 +92,7 @@ This example is on Linux Ubuntu 24.04 distribution!
 ### 4. Login
 
 Login with your browser:
-- [https://cloud.opencloud.test](https://cloud.opencloud.test)
+- [https://localhost:9200](https://localhost:9200)
 - user: **admin**
 - password: **admin**
 


### PR DESCRIPTION
<img width="357" alt="image" src="https://github.com/user-attachments/assets/9db8518d-4789-436d-8df7-4c7c9f2f7cbf" />

fixed url in the https://docs.opencloud.eu/docs/admin/getting-started/other/bare-metal