### PR TITLE
Fix build instruction

### DIFF
--- a/docs/admin/getting-started/other/bare-metal.md
+++ b/docs/admin/getting-started/other/bare-metal.md
@@ -72,7 +72,8 @@ This example is on Linux Ubuntu 24.04 distribution!
    
 - Run the build generate process:
    ```bash
-   make clean generate -C opencloud build
+   make clean generate
+   make -C opencloud build
    ```
 
 - Initialize OpenCloud with insecure configuration and set an admin password:


### PR DESCRIPTION
At least with GNU make the `-C` option is not target specific. So for now we need two make calls.

Fixes #216