### PR TITLE
Add design-system docs to build

### DIFF
--- a/.batchfile
+++ b/.batchfile
@@ -1,0 +1,3 @@
+# Usage: <RepoUrl>;branch;TargetFolder
+
+https://github.com/opencloud-eu/web;design-system-docs;static/design-system

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /build
 /static/likec4
 
+# design-system docs
+/static/design-system
+
 # Generated files
 .docusaurus
 .cache-loader

--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -2,9 +2,13 @@
 when:
   - event: push
     branch: ${CI_REPO_DEFAULT_BRANCH}
-  - event: [ pull_request, manual, tag]
+  - event: [pull_request, manual, tag]
 
 steps:
+  - name: fetch-design-system-docs
+    image: quay.io/thegeeklab/git-batch
+    commands:
+      - git batch -vv
   - name: build
     image: owncloudci/nodejs:20
     commands:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "build-likec4": "likec4 build ./assets/likec4 --base /likec4 -o ./static/likec4"
+    "build-likec4": "likec4 build ./assets/likec4 --base /likec4 -o ./static/likec4",
+    "fetch-design-system-docs": "docker run --rm -w $(pwd) -v $(pwd):$(pwd)  quay.io/thegeeklab/git-batch"
   },
   "dependencies": {
     "@docusaurus/core": "3.7.0",


### PR DESCRIPTION
Adds a ci step to fetch the design-system docs from the web repository so they get included in the final build of the docs.

Also adds the command `pnpm fetch-design-system-docs` to fetch them locally. Run this before running `pnpm start` to include the design-systems docs in your local build.

refs https://github.com/opencloud-eu/web/issues/217