### PR TITLE
🎉 Release 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 👷 Admin Documentation
 
+- add note, that the raspberry pi installation is for private use [[#260](https://github.com/opencloud-eu/docs/pull/260)]
 - Add more doc about the collaborative mode [[#254](https://github.com/opencloud-eu/docs/pull/254)]
 
 ### 👤 User Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.19.1](https://github.com/opencloud-eu/docs/releases/tag/1.19.1) - 2025-04-25
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Svanvith
+
+
+
 ## [1.19.0](https://github.com/opencloud-eu/docs/releases/tag/1.19.0) - 2025-04-24
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
-## [1.19.1](https://github.com/opencloud-eu/docs/releases/tag/1.19.1) - 2025-04-25
+## [1.20.0](https://github.com/opencloud-eu/docs/releases/tag/1.20.0) - 2025-04-28
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Svanvith
+@Svanvith, @dragotin
 
+### 👷 Admin Documentation
 
+- Add more doc about the collaborative mode [[#254](https://github.com/opencloud-eu/docs/pull/254)]
+
+### 👤 User Documentation
+
+- Rewrite desktop installation [[#255](https://github.com/opencloud-eu/docs/pull/255)]
 
 ## [1.19.0](https://github.com/opencloud-eu/docs/releases/tag/1.19.0) - 2025-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Svanvith, @dragotin
+@AlexAndBear, @Svanvith, @dragotin
 
 ### 👷 Admin Documentation
 
+- Rename docker to container in admin -> getting started [[#259](https://github.com/opencloud-eu/docs/pull/259)]
 - add note, that the raspberry pi installation is for private use [[#260](https://github.com/opencloud-eu/docs/pull/260)]
 - Add more doc about the collaborative mode [[#254](https://github.com/opencloud-eu/docs/pull/254)]
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.20.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.20.0](https://github.com/opencloud-eu/docs/releases/tag/1.20.0) - 2025-04-28

### 👷 Admin Documentation

- Rename docker to container in admin -> getting started [[#259](https://github.com/opencloud-eu/docs/pull/259)]
- add note, that the raspberry pi installation is for private use [[#260](https://github.com/opencloud-eu/docs/pull/260)]
- Add more doc about the collaborative mode [[#254](https://github.com/opencloud-eu/docs/pull/254)]

### 👤 User Documentation

- Rewrite desktop installation [[#255](https://github.com/opencloud-eu/docs/pull/255)]