### PR TITLE
🎉 Release 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@LisaHue
+@Heiko-Pohl, @LisaHue
 
 ### 👤 User Documentation
 
+- translation tutorial sidebar iOS app [[#314](https://github.com/opencloud-eu/docs/pull/314)]
 - undraft the iOS articles [[#312](https://github.com/opencloud-eu/docs/pull/312)]
 
 ## [1.27.0](https://github.com/opencloud-eu/docs/releases/tag/1.27.0) - 2025-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.28.0](https://github.com/opencloud-eu/docs/releases/tag/1.28.0) - 2025-05-20
+
+### ❤️ Thanks to all contributors! ❤️
+
+@LisaHue
+
+### 👤 User Documentation
+
+- undraft the iOS articles [[#312](https://github.com/opencloud-eu/docs/pull/312)]
+
 ## [1.27.0](https://github.com/opencloud-eu/docs/releases/tag/1.27.0) - 2025-05-20
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.28.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.28.0](https://github.com/opencloud-eu/docs/releases/tag/1.28.0) - 2025-05-20

### 👤 User Documentation

- translation tutorial sidebar iOS app [[#314](https://github.com/opencloud-eu/docs/pull/314)]
- undraft the iOS articles [[#312](https://github.com/opencloud-eu/docs/pull/312)]