### PR TITLE
🎉 Release 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.33.0](https://github.com/opencloud-eu/docs/releases/tag/1.33.0) - 2025-06-04
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Heiko-Pohl
+
+### 👤 User Documentation
+
+- Android app tutorials english [[#323](https://github.com/opencloud-eu/docs/pull/323)]
+
 ## [1.32.0](https://github.com/opencloud-eu/docs/releases/tag/1.32.0) - 2025-06-02
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Heiko-Pohl
+@Heiko-Pohl, @Svanvith
+
+### 👷 Admin Documentation
+
+- added that webdav info need to be enabled in the preferences [[#335](https://github.com/opencloud-eu/docs/pull/335)]
 
 ### 👤 User Documentation
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.33.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.33.0](https://github.com/opencloud-eu/docs/releases/tag/1.33.0) - 2025-06-04

### 👷 Admin Documentation

- added that webdav info need to be enabled in the preferences [[#335](https://github.com/opencloud-eu/docs/pull/335)]

### 👤 User Documentation

- Android app tutorials english [[#323](https://github.com/opencloud-eu/docs/pull/323)]