### PR TITLE
🎉 Release 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.34.0](https://github.com/opencloud-eu/docs/releases/tag/1.34.0) - 2025-06-06
+
+### ❤️ Thanks to all contributors! ❤️
+
+@LisaHue
+
+### 👷 Admin Documentation
+
+- Updated Link in Web Applications [[#336](https://github.com/opencloud-eu/docs/pull/336)]
+
 ## [1.33.0](https://github.com/opencloud-eu/docs/releases/tag/1.33.0) - 2025-06-04
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 👷 Admin Documentation
 
+- improve release notes [[#340](https://github.com/opencloud-eu/docs/pull/340)]
 - release notes for 3.0.0 rolling release [[#338](https://github.com/opencloud-eu/docs/pull/338)]
 - Updated Link in Web Applications [[#336](https://github.com/opencloud-eu/docs/pull/336)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## [1.34.0](https://github.com/opencloud-eu/docs/releases/tag/1.34.0) - 2025-06-06
+## [1.34.0](https://github.com/opencloud-eu/docs/releases/tag/1.34.0) - 2025-06-11
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@LisaHue
+@LisaHue, @ScharfViktor
 
 ### 👷 Admin Documentation
 
+- release notes for 3.0.0 rolling release [[#338](https://github.com/opencloud-eu/docs/pull/338)]
 - Updated Link in Web Applications [[#336](https://github.com/opencloud-eu/docs/pull/336)]
 
 ## [1.33.0](https://github.com/opencloud-eu/docs/releases/tag/1.33.0) - 2025-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## [1.34.0](https://github.com/opencloud-eu/docs/releases/tag/1.34.0) - 2025-06-11
+## [1.34.0](https://github.com/opencloud-eu/docs/releases/tag/1.34.0) - 2025-06-13
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@LisaHue, @ScharfViktor
+@LisaHue, @ScharfViktor, @Svanvith
 
 ### 👷 Admin Documentation
 
+- move release notes to the upgrade part and put it together under one … [[#342](https://github.com/opencloud-eu/docs/pull/342)]
 - improve release notes [[#340](https://github.com/opencloud-eu/docs/pull/340)]
 - release notes for 3.0.0 rolling release [[#338](https://github.com/opencloud-eu/docs/pull/338)]
 - Updated Link in Web Applications [[#336](https://github.com/opencloud-eu/docs/pull/336)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@LisaHue, @ScharfViktor, @Svanvith
+@Heiko-Pohl, @LisaHue, @ScharfViktor, @Svanvith
 
 ### 👷 Admin Documentation
 
+- Mail Notifications [[#343](https://github.com/opencloud-eu/docs/pull/343)]
 - move release notes to the upgrade part and put it together under one … [[#342](https://github.com/opencloud-eu/docs/pull/342)]
 - improve release notes [[#340](https://github.com/opencloud-eu/docs/pull/340)]
 - release notes for 3.0.0 rolling release [[#338](https://github.com/opencloud-eu/docs/pull/338)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.34.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.34.0](https://github.com/opencloud-eu/docs/releases/tag/1.34.0) - 2025-06-13

### 👷 Admin Documentation

- Mail Notifications [[#343](https://github.com/opencloud-eu/docs/pull/343)]
- move release notes to the upgrade part and put it together under one … [[#342](https://github.com/opencloud-eu/docs/pull/342)]
- improve release notes [[#340](https://github.com/opencloud-eu/docs/pull/340)]
- release notes for 3.0.0 rolling release [[#338](https://github.com/opencloud-eu/docs/pull/338)]
- Updated Link in Web Applications [[#336](https://github.com/opencloud-eu/docs/pull/336)]