### PR TITLE
release notes for 3.0.0 rolling release

### DIFF
--- a/docs/admin/resources/common-issues.md
+++ b/docs/admin/resources/common-issues.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 id: common-issues
 title: Common Issues & Help
 ---

--- a/docs/admin/resources/demo-user.md
+++ b/docs/admin/resources/demo-user.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 id: demo-user
 title: Demo User
 ---

--- a/docs/admin/resources/lifecycle.md
+++ b/docs/admin/resources/lifecycle.md
@@ -39,7 +39,7 @@ With LTS, businesses can continue using an older production release without need
     | - | 2025 August 11 | - |
     | - | 2025 July 21 | - |
     | - | 2025 June 30 | - |
-    | - | 2025 June 10 | - |
+    | v3.0.0 | 2025 June 10 | [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v3.0.0) |
     | v2.3.0 | 2025 May 19 | [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v2.3.0) |
     | v2.2.0 | 2025 April 28 | [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v2.2.0) |
     | v2.1.0 | 2025 April 07 | [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v2.1.0) |

--- a/docs/admin/resources/release-notes.md
+++ b/docs/admin/resources/release-notes.md
@@ -9,6 +9,7 @@ draft: false
 
 - Version: 3.0.0
 - Type: Major Release (Breaking Changes)
+- [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v3.0.0)
 
 ## Key Changes
 ### Performance Optimization (Breaking Change)

--- a/docs/admin/resources/release-notes.md
+++ b/docs/admin/resources/release-notes.md
@@ -1,0 +1,30 @@
+---
+sidebar_position: 3
+id: release-notes
+title: "Release Notes"
+draft: false
+---
+
+# 📦 Release Notes: Migration from v2.x.x to v3.0.0
+
+- Version: 3.0.0
+- Type: Major Release (Breaking Changes)
+
+## Key Changes
+### Performance Optimization (Breaking Change)
+#### Old Behavior:
+
+```
+GET /drives/{drive-id}/root/permissions
+```
+
+👉 Automatically returned full permission details with all nested properties.
+
+
+#### New Behavior:
+
+```
+GET /drives/{drive-id}/root/permissions?$select=@libre.graph.permissions.actions.allowedValues
+```
+
+👉 Now requires explicit selection of needed fields. 


### PR DESCRIPTION
part of https://github.com/opencloud-eu/opencloud/issues/1029

We need explain users a reason major release so I created `release notes` page and placed it close to `release lifecycle`

There was suggestion to put it close to upgrade section (https://docs.opencloud.eu/docs/admin/maintenance/update) but in my opinion, I placed it in the right place.
I have tried to briefly explain the reason of major release. If you have any suggestions or recommendations, please let me know.