### PR TITLE
🎉 Release 1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.36.0](https://github.com/opencloud-eu/docs/releases/tag/1.36.0) - 2025-06-25
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Svanvith
+
+### 👷 Admin Documentation
+
+- change /home/chaser to /home/user [[#348](https://github.com/opencloud-eu/docs/pull/348)]
+
 ## [1.35.0](https://github.com/opencloud-eu/docs/releases/tag/1.35.0) - 2025-06-23
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [1.36.0](https://github.com/opencloud-eu/docs/releases/tag/1.36.0) - 2025-06-25
+## [1.36.0](https://github.com/opencloud-eu/docs/releases/tag/1.36.0) - 2025-06-30
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Svanvith
+@Svanvith, @tbsbdr
 
 ### 👷 Admin Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Svanvith, @tbsbdr
+@ScharfViktor, @Svanvith, @tbsbdr
 
 ### 👷 Admin Documentation
 
+- publish 3.1.0 release in the docs [[#352](https://github.com/opencloud-eu/docs/pull/352)]
 - change /home/chaser to /home/user [[#348](https://github.com/opencloud-eu/docs/pull/348)]
 
 ## [1.35.0](https://github.com/opencloud-eu/docs/releases/tag/1.35.0) - 2025-06-23


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.36.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.36.0](https://github.com/opencloud-eu/docs/releases/tag/1.36.0) - 2025-06-30

### 👷 Admin Documentation

- publish 3.1.0 release in the docs [[#352](https://github.com/opencloud-eu/docs/pull/352)]
- change /home/chaser to /home/user [[#348](https://github.com/opencloud-eu/docs/pull/348)]