### PR TITLE
🎉 Release 1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.37.0](https://github.com/opencloud-eu/docs/releases/tag/1.37.0) - 2025-07-01
+## [1.37.0](https://github.com/opencloud-eu/docs/releases/tag/1.37.0) - 2025-07-02
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### 👷 Admin Documentation
 
+- rewrite the raspberry pi tutorial to match to the new compose repo [[#355](https://github.com/opencloud-eu/docs/pull/355)]
 - change structure for deployment with docker compose [[#353](https://github.com/opencloud-eu/docs/pull/353)]
 
 ## [1.36.0](https://github.com/opencloud-eu/docs/releases/tag/1.36.0) - 2025-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Svanvith, @fschade
+@AlexAndBear, @Svanvith, @fschade
+
+### :octocat: Developer Documentation
+
+- add libre graph api url to server documentation [[#357](https://github.com/opencloud-eu/docs/pull/357)]
 
 ### 👷 Admin Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.37.0](https://github.com/opencloud-eu/docs/releases/tag/1.37.0) - 2025-07-01
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Svanvith
+
+### 👷 Admin Documentation
+
+- change structure for deployment with docker compose [[#353](https://github.com/opencloud-eu/docs/pull/353)]
+
 ## [1.36.0](https://github.com/opencloud-eu/docs/releases/tag/1.36.0) - 2025-06-30
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Svanvith
+@Svanvith, @fschade
 
 ### 👷 Admin Documentation
 
 - rewrite the raspberry pi tutorial to match to the new compose repo [[#355](https://github.com/opencloud-eu/docs/pull/355)]
 - change structure for deployment with docker compose [[#353](https://github.com/opencloud-eu/docs/pull/353)]
+
+### 📦️ Build&Tools
+
+- enhancement(docs): add cdperf documentation [[#358](https://github.com/opencloud-eu/docs/pull/358)]
 
 ## [1.36.0](https://github.com/opencloud-eu/docs/releases/tag/1.36.0) - 2025-06-30
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.37.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.37.0](https://github.com/opencloud-eu/docs/releases/tag/1.37.0) - 2025-07-02

### :octocat: Developer Documentation

- add libre graph api url to server documentation [[#357](https://github.com/opencloud-eu/docs/pull/357)]

### 👷 Admin Documentation

- rewrite the raspberry pi tutorial to match to the new compose repo [[#355](https://github.com/opencloud-eu/docs/pull/355)]
- change structure for deployment with docker compose [[#353](https://github.com/opencloud-eu/docs/pull/353)]

### 📦️ Build&Tools

- enhancement(docs): add cdperf documentation [[#358](https://github.com/opencloud-eu/docs/pull/358)]