### PR TITLE
Make rightmost table-column heading left-aligned

### DIFF
--- a/static/env-vars/activitylog_configvars.md
+++ b/static/env-vars/activitylog_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **activitylog** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`ACTIVITYLOG_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`ACTIVITYLOG_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`ACTIVITYLOG_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/antivirus_configvars.md
+++ b/static/env-vars/antivirus_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **antivirus** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_LOG_LEVEL`<br/>`ANTIVIRUS_LOG_LEVEL`| 1.0.0 |string|The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'.||
 |`OC_LOG_PRETTY`<br/>`ANTIVIRUS_LOG_PRETTY`| 1.0.0 |bool|Activates pretty log output.|false|
 |`OC_LOG_COLOR`<br/>`ANTIVIRUS_LOG_COLOR`| 1.0.0 |bool|Activates colorized log output.|false|

--- a/static/env-vars/app-provider_configvars.md
+++ b/static/env-vars/app-provider_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **app-provider** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`APP_PROVIDER_SERVICE_NAME`| 1.0.0 |string|The name of the service. This needs to be changed when using more than one app provider. Each app provider configured needs to be identified by a unique service name. Possible examples are: 'app-provider-collabora', 'app-provider-onlyoffice', 'app-provider-office365'.|app-provider|
 |`OC_TRACING_ENABLED`<br/>`APP_PROVIDER_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`APP_PROVIDER_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||

--- a/static/env-vars/app-registry_configvars.md
+++ b/static/env-vars/app-registry_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **app-registry** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`APP_REGISTRY_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`APP_REGISTRY_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`APP_REGISTRY_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/audit_configvars.md
+++ b/static/env-vars/audit_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **audit** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`AUDIT_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`AUDIT_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`AUDIT_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/auth-app_configvars.md
+++ b/static/env-vars/auth-app_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **auth-app** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`AUTH_APP_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`AUTH_APP_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`AUTH_APP_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/auth-basic_configvars.md
+++ b/static/env-vars/auth-basic_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **auth-basic** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`AUTH_BASIC_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`AUTH_BASIC_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`AUTH_BASIC_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/auth-bearer_configvars.md
+++ b/static/env-vars/auth-bearer_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **auth-bearer** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`AUTH_BEARER_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`AUTH_BEARER_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`AUTH_BEARER_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/auth-machine_configvars.md
+++ b/static/env-vars/auth-machine_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **auth-machine** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`AUTH_MACHINE_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`AUTH_MACHINE_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`AUTH_MACHINE_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/auth-service_configvars.md
+++ b/static/env-vars/auth-service_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **auth-service** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`AUTH_SERVICE_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`AUTH_SERVICE_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`AUTH_SERVICE_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/clientlog_configvars.md
+++ b/static/env-vars/clientlog_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **clientlog** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`CLIENTLOG_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`CLIENTLOG_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`CLIENTLOG_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/collaboration_configvars.md
+++ b/static/env-vars/collaboration_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **collaboration** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`COLLABORATION_APP_NAME`| 1.0.0 |string|The name of the app which is shown to the user. You can chose freely but you are limited to a single word without special characters or whitespaces. We recommend to use pascalCase like 'CollaboraOnline'.|Collabora|
 |`COLLABORATION_APP_PRODUCT`| 1.0.0 |string|The WebOffice app, either Collabora, OnlyOffice, Microsoft365 or MicrosoftOfficeOnline.||
 |`COLLABORATION_APP_DESCRIPTION`| 1.0.0 |string|App description|Open office documents with Collabora|

--- a/static/env-vars/eventhistory_configvars.md
+++ b/static/env-vars/eventhistory_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **eventhistory** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`EVENTHISTORY_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`EVENTHISTORY_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`EVENTHISTORY_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/frontend_configvars.md
+++ b/static/env-vars/frontend_configvars.md
@@ -24,7 +24,7 @@
 Environment variables for the **frontend** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`FRONTEND_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`FRONTEND_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`FRONTEND_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/gateway_configvars.md
+++ b/static/env-vars/gateway_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **gateway** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`GATEWAY_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`GATEWAY_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`GATEWAY_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/global_configvars.md
+++ b/static/env-vars/global_configvars.md
@@ -1,7 +1,7 @@
 #Environment variables with global scope available in multiple services
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 `IDM_CREATE_DEMO_USERS` | 1.0.0 | bool | Flag to enable or disable the creation of the demo users. | false |
 `OC_ADMIN_USER_ID` | 1.0.0 | string | ID of the user that should receive admin privileges. Consider that the UUID can be encoded in some LDAP deployment configurations like in .ldif files. These need to be decoded beforehand. |  |
 `OC_ASYNC_UPLOADS` | 1.0.0 | bool | Enable asynchronous file uploads. | true |

--- a/static/env-vars/graph_configvars.md
+++ b/static/env-vars/graph_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **graph** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`GRAPH_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`GRAPH_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`GRAPH_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/groups_configvars.md
+++ b/static/env-vars/groups_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **groups** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`GROUPS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`GROUPS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`GROUPS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/idm_configvars.md
+++ b/static/env-vars/idm_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **idm** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`IDM_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`IDM_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`IDM_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/idp_configvars.md
+++ b/static/env-vars/idp_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **idp** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`IDP_PASSWORD_RESET_URI`| 1.0.0 |string|The URI where a user can reset their password.||
 |`OC_TRACING_ENABLED`<br/>`IDP_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`IDP_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||

--- a/static/env-vars/invitations_configvars.md
+++ b/static/env-vars/invitations_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **invitations** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`INVITATIONS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`INVITATIONS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`INVITATIONS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/nats_configvars.md
+++ b/static/env-vars/nats_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **nats** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`NATS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`NATS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`NATS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/notifications_configvars.md
+++ b/static/env-vars/notifications_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **notifications** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`NOTIFICATIONS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`NOTIFICATIONS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`NOTIFICATIONS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/ocdav_configvars.md
+++ b/static/env-vars/ocdav_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **ocdav** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`OCDAV_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`OCDAV_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`OCDAV_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/ocm_configvars.md
+++ b/static/env-vars/ocm_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **ocm** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`OCM_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`OCM_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`OCM_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/ocs_configvars.md
+++ b/static/env-vars/ocs_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **ocs** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`OCS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`OCS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`OCS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/policies_configvars.md
+++ b/static/env-vars/policies_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **policies** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`POLICIES_GRPC_ADDR`| 1.0.0 |string|The bind address of the GRPC service.|127.0.0.1:9125|
 |`POLICIES_DEBUG_ADDR`| 1.0.0 |string|Bind address of the debug server, where metrics, health, config and debug endpoints will be exposed.|127.0.0.1:9129|
 |`POLICIES_DEBUG_TOKEN`| 1.0.0 |string|Token to secure the metrics endpoint.||

--- a/static/env-vars/postprocessing_configvars.md
+++ b/static/env-vars/postprocessing_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **postprocessing** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`POSTPROCESSING_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`POSTPROCESSING_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`POSTPROCESSING_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/proxy_configvars.md
+++ b/static/env-vars/proxy_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **proxy** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`PROXY_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`PROXY_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`PROXY_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/search_configvars.md
+++ b/static/env-vars/search_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **search** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`SEARCH_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`SEARCH_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`SEARCH_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/settings_configvars.md
+++ b/static/env-vars/settings_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **settings** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`SETTINGS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`SETTINGS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`SETTINGS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/sharing_configvars.md
+++ b/static/env-vars/sharing_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **sharing** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`SHARING_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`SHARING_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`SHARING_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/sse_configvars.md
+++ b/static/env-vars/sse_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **sse** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_LOG_LEVEL`<br/>`SSE_LOG_LEVEL`| 1.0.0 |string|The log level. Valid values are: 'panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace'.||
 |`OC_LOG_PRETTY`<br/>`SSE_LOG_PRETTY`| 1.0.0 |bool|Activates pretty log output.|false|
 |`OC_LOG_COLOR`<br/>`SSE_LOG_COLOR`| 1.0.0 |bool|Activates colorized log output.|false|

--- a/static/env-vars/storage-publiclink_configvars.md
+++ b/static/env-vars/storage-publiclink_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **storage-publiclink** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`STORAGE_PUBLICLINK_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`STORAGE_PUBLICLINK_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`STORAGE_PUBLICLINK_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/storage-shares_configvars.md
+++ b/static/env-vars/storage-shares_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **storage-shares** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`STORAGE_SHARES_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`STORAGE_SHARES_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`STORAGE_SHARES_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/storage-system_configvars.md
+++ b/static/env-vars/storage-system_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **storage-system** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`STORAGE_SYSTEM_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`STORAGE_SYSTEM_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`STORAGE_SYSTEM_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/storage-users_configvars.md
+++ b/static/env-vars/storage-users_configvars.md
@@ -9,7 +9,7 @@
 Environment variables for the **storage-users** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`STORAGE_USERS_SERVICE_NAME`| 1.0.0 |string|Service name to use. Change this when starting an additional storage provider with a custom configuration to prevent it from colliding with the default 'storage-users' service.|storage-users|
 |`OC_TRACING_ENABLED`<br/>`STORAGE_USERS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`STORAGE_USERS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||

--- a/static/env-vars/thumbnails_configvars.md
+++ b/static/env-vars/thumbnails_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **thumbnails** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`THUMBNAILS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`THUMBNAILS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`THUMBNAILS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/userlog_configvars.md
+++ b/static/env-vars/userlog_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **userlog** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`USERLOG_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`USERLOG_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`USERLOG_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/users_configvars.md
+++ b/static/env-vars/users_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **users** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`USERS_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`USERS_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`USERS_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/web_configvars.md
+++ b/static/env-vars/web_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **web** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`WEB_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`WEB_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`WEB_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/webdav_configvars.md
+++ b/static/env-vars/webdav_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **webdav** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`WEBDAV_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`WEBDAV_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`WEBDAV_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||

--- a/static/env-vars/webfinger_configvars.md
+++ b/static/env-vars/webfinger_configvars.md
@@ -1,7 +1,7 @@
 Environment variables for the **webfinger** service
 
 | Name | Introduction Version | Type | Description | Default Value |
-|---|---|---|---|---|
+|---|---|---|---|:---|
 |`OC_TRACING_ENABLED`<br/>`WEBFINGER_TRACING_ENABLED`| 1.0.0 |bool|Activates tracing.|false|
 |`OC_TRACING_TYPE`<br/>`WEBFINGER_TRACING_TYPE`| 1.0.0 |string|The type of tracing. Defaults to '', which is the same as 'jaeger'. Allowed tracing types are 'jaeger' and '' as of now.||
 |`OC_TRACING_ENDPOINT`<br/>`WEBFINGER_TRACING_ENDPOINT`| 1.0.0 |string|The endpoint of the tracing agent.||


### PR DESCRIPTION
If a table is cut of on the right (which is mostly the case on my screen), you are still able to read the text in rightmost column but the heading of that column is not readable/visible beacuse it is a center-aligned text. I would like to see that headline to be left-aligned.
