### PR TITLE
🎉 Release 1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Svanvith
+@LisaHue, @Svanvith
 
 ### 👷 Admin Documentation
 
+- Refine docker-compose local [[#368](https://github.com/opencloud-eu/docs/pull/368)]
 - add instructions to deinstall opencloud [[#367](https://github.com/opencloud-eu/docs/pull/367)]
 
 ## [1.37.0](https://github.com/opencloud-eu/docs/releases/tag/1.37.0) - 2025-07-02


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.38.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.38.0](https://github.com/opencloud-eu/docs/releases/tag/1.38.0) - 2025-07-10

### 👷 Admin Documentation

- Refine docker-compose local [[#368](https://github.com/opencloud-eu/docs/pull/368)]
- add instructions to deinstall opencloud [[#367](https://github.com/opencloud-eu/docs/pull/367)]