### PR TITLE
🎉 Release 1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.41.0](https://github.com/opencloud-eu/docs/releases/tag/1.41.0) - 2025-07-23
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Svanvith
+
+### 👤 User Documentation
+
+- rework user admin de and set kubernetes to draft:false [[#409](https://github.com/opencloud-eu/docs/pull/409)]
+
 ## [1.40.0](https://github.com/opencloud-eu/docs/releases/tag/1.40.0) - 2025-07-23
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.41.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.41.0](https://github.com/opencloud-eu/docs/releases/tag/1.41.0) - 2025-07-23

### 👤 User Documentation

- rework user admin de and set kubernetes to draft:false [[#409](https://github.com/opencloud-eu/docs/pull/409)]