### PR TITLE
unneeded "Clone the OpenCloud Repository" section

### DIFF
--- a/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md
+++ b/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md
@@ -48,14 +48,6 @@ Once Docker is installed, enable and start the service:
 systemctl enable docker && systemctl start docker
 ```
 
-## Clone the OpenCloud Repository
-
-Download the necessary configuration files:
-
-```bash
-git clone https://github.com/opencloud-eu/opencloud-compose.git
-```
-
 ## Install Nginx & Certbot
 
 Now install Nginx & Certbot


### PR DESCRIPTION
[Clone the OpenCloud Repository](https://github.com/opencloud-eu/docs/blob/main/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md#clone-the-opencloud-repository) is unneeded as readers are instructed to do this into [Configure and start OpenCloud](https://github.com/opencloud-eu/docs/blob/main/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md#configure-and-start-opencloud) section.