### PR TITLE
adjust custom css so we can hide instructions in the sidebar and hide…

### DIFF
--- a/docs/admin/getting-started/container/docker-compose-local.md
+++ b/docs/admin/getting-started/container/docker-compose-local.md
@@ -4,6 +4,7 @@ id: docker-compose-local
 title: Docker Compose local
 description: Full-blown featureset including web office and full-text search.
 draft: false
+sidebar_class_name: hidden
 ---
 
 # Guide for local installation

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -83,3 +83,8 @@
 [data-theme='dark'] .dark-mode-image {
     display: block;
 }
+
+/* For outdated instructions which should be hidden but still available via linked URL. */
+.menu__list-item.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
… docker compose local

@AlexAndBear could you please have a look if it is ok what I added to the custom.css?

With this we can still have instructions which are outdated and should no be longe in the sidebar, but they still exists and can be reached with the old URL