### PR TITLE
🎉 Release 1.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.50.1](https://github.com/opencloud-eu/docs/releases/tag/1.50.1) - 2025-09-09
+
+### ❤️ Thanks to all contributors! ❤️
+
+@AlexAndBear
+
+### 📦️ Build&Tools
+
+- chore: update docusaurus to 3.8.1 [[#459](https://github.com/opencloud-eu/docs/pull/459)]
+
 ## [1.50.0](https://github.com/opencloud-eu/docs/releases/tag/1.50.0) - 2025-09-09
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.50.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.50.1](https://github.com/opencloud-eu/docs/releases/tag/1.50.1) - 2025-09-09

### 📦️ Build&Tools

- chore: update docusaurus to 3.8.1 [[#459](https://github.com/opencloud-eu/docs/pull/459)]