### PR TITLE
🎉 Release 1.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.52.0](https://github.com/opencloud-eu/docs/releases/tag/1.52.0) - 2025-09-22
+
+### ❤️ Thanks to all contributors! ❤️
+
+@ScharfViktor
+
+### 👷 Admin Documentation
+
+- publish release note 3.5.0 [[#466](https://github.com/opencloud-eu/docs/pull/466)]
+
 ## [1.51.1](https://github.com/opencloud-eu/docs/releases/tag/1.51.1) - 2025-09-19
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## [1.52.0](https://github.com/opencloud-eu/docs/releases/tag/1.52.0) - 2025-09-22
+## [1.52.0](https://github.com/opencloud-eu/docs/releases/tag/1.52.0) - 2025-09-25
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@ScharfViktor
+@ScharfViktor, @tbsbdr
 
 ### 👷 Admin Documentation
 
+- removed soon from ios android [[#465](https://github.com/opencloud-eu/docs/pull/465)]
 - publish release note 3.5.0 [[#466](https://github.com/opencloud-eu/docs/pull/466)]
 
 ## [1.51.1](https://github.com/opencloud-eu/docs/releases/tag/1.51.1) - 2025-09-19


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.52.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.52.0](https://github.com/opencloud-eu/docs/releases/tag/1.52.0) - 2025-09-25

### 👷 Admin Documentation

- removed soon from ios android [[#465](https://github.com/opencloud-eu/docs/pull/465)]
- publish release note 3.5.0 [[#466](https://github.com/opencloud-eu/docs/pull/466)]