### PR TITLE
Add: Reference to envionement variables in developers docs

### DIFF
--- a/docs/admin/configuration/mail-notifications.md
+++ b/docs/admin/configuration/mail-notifications.md
@@ -35,7 +35,10 @@ SMTP_USERNAME=YOUR_USERNAME
 SMTP_PASSWORD=YOUR_PASSWORD
 SMTP_TRANSPORT_ENCRYPTION=none
 SMTP_INSECURE=true
+SMTP_AUTHENTICATION=auto
 ```
+
+See section [Environment Variables](https://docs.opencloud.eu/docs/dev/server/Services/notifications/notifications-envvars/) in the developers documentation for possible values for these variables. Note, that the environment variables are prefixed with `NOTIFICATIONS_`, so `NOTIFICATIONS_SMTP_AUTHENTICATION` shows possible values for `SMTP_AUTHENTICATION` in the `.env` file.
 
 Per default the `notifications` service is disabled. To send out notifications, the service must be enabled via:
 


### PR DESCRIPTION
- I was looking where to find possible values for the SMTP variables.
- Admins might not expect to find those in the developer docs.
- Add reference to section Environment Variables in developers docs.
- Solves https://github.com/opencloud-eu/opencloud-compose/issues/120.
- Docs:Admin

Please let me know if something is unclear and needs elaboration.

Cheers,  
Tronde