### PR TITLE
Fix "Authentication and Identymanagment" spelling error

### DIFF
--- a/docs/admin/configuration/authentication-and-user-management/_category_.json
+++ b/docs/admin/configuration/authentication-and-user-management/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Authentication and Identymanagment",
+  "label": "Authentication and Identity Management",
   "position": 10
 }


### PR DESCRIPTION
Replace "Authentication and Identymanagment" with "Authentication and Identity Management" category title.