### PR TITLE
fix: adjust bare-metal install guide

### DIFF
--- a/docs/admin/getting-started/other/bare-metal.md
+++ b/docs/admin/getting-started/other/bare-metal.md
@@ -88,6 +88,12 @@ Bare-metal deployments are not officially supported by OpenCloud. They are great
   make -C opencloud build
   ```
 
+- Navigate into the opencloud subdirectory that was just built:
+
+  ```bash
+  cd opencloud
+  ```
+
 - Initialize OpenCloud with insecure configuration and set an admin password:
 
   ```bash


### PR DESCRIPTION
After `make -C opencloud build` the built artifacts are in a subdirectory called `opencloud`
In the `opencloud` subdirectory is the `bin` directory.

You can either:
- navigate down into the just-built `opencloud` directory, then follow the existing instructions after that, or;
- prepend `/owncloud` to each of the existing documented commands (e.g. `./opencloud/bin/opencloud server` )

This PR just adds a `cd opencloud` to the instructions.