### PR TITLE
correct environment variable for custom coonfig path: OC_CONFIG_DIR

### DIFF
--- a/docs/dev/server/configuration/config-system.md
+++ b/docs/dev/server/configuration/config-system.md
@@ -24,7 +24,7 @@ Default values for all configuration options are built into each service. You on
   - Mount this directory into containers (Docker, Kubernetes) via ConfigMaps/Secrets or volumes.
 - Binary releases and local installs: `$HOME/.opencloud/config/`
   - Useful when running downloaded binaries on developer laptops or bare hosts without container mounts.
-- The location for the configuration files can be changed by setting the environment variable `OC_CONFIG_PATH` to point to a different directory.
+- The location for the configuration files can be changed by setting the environment variable `OC_CONFIG_DIR` to point to a different directory.
 - Typical files inside either location:
   - `opencloud.yaml` — global defaults shared by all services
   - `<service-name>.yaml` — overrides specific to a service (e.g. `activitylog.yaml`, `proxy.yaml`)

--- a/versioned_docs/version-4.0.0/dev/server/configuration/config-system.md
+++ b/versioned_docs/version-4.0.0/dev/server/configuration/config-system.md
@@ -24,7 +24,7 @@ Default values for all configuration options are built into each service. You on
   - Mount this directory into containers (Docker, Kubernetes) via ConfigMaps/Secrets or volumes.
 - Binary releases and local installs: `$HOME/.opencloud/config/`
   - Useful when running downloaded binaries on developer laptops or bare hosts without container mounts.
-- The location for the configuration files can be changed by setting the environment variable `OC_CONFIG_PATH` to point to a different directory.
+- The location for the configuration files can be changed by setting the environment variable `OC_CONFIG_DIR` to point to a different directory.
 - Typical files inside either location:
   - `opencloud.yaml` — global defaults shared by all services
   - `<service-name>.yaml` — overrides specific to a service (e.g. `activitylog.yaml`, `proxy.yaml`)


### PR DESCRIPTION
Problem:
In the "Configuration Locations" section, the environment variable for setting a custom config path is listed as `OC_CONFIG_PATH`. When I run the plain binary (in bare-metal installation) , `OC_CONFIG_PATH` does not work to change the config path. `OC_CONFIG_DIR` has to be used.

Actual behavior:
The correct variable is `OC_CONFIG_DIR`. `OC_CONFIG_PATH `does not exist anywhere in the code.

References: 

- [Code reference](https://github.com/opencloud-eu/opencloud/blob/4c5d5fb218de4e8c09544900b9000213c51e23f8/pkg/config/defaults/paths.go#L54)
- [GitHub search for OC_CONFIG_PATH in the repo](https://github.com/search?q=repo:opencloud-eu/opencloud+OC_CONFIG_PATH&type=code) → no results
- [Section in the docs](https://docs.opencloud.eu/docs/next/dev/server/configuration/config-system#configuration-locations)