### PR TITLE
Duplicated nginx config options in docs

### DIFF
--- a/versioned_docs/version-4.0.0/admin/getting-started/container/docker-compose/docker-external-proxy.md
+++ b/versioned_docs/version-4.0.0/admin/getting-started/container/docker-compose/docker-external-proxy.md
@@ -183,19 +183,6 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/cloud.YOUR.DOMAIN/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/cloud.YOUR.DOMAIN/privkey.pem;
-    # Increase max upload size (required for Tus — without this, uploads over 1 MB fail)
-    client_max_body_size 10M;
-    # Disable buffering - essential for SSE
-    proxy_buffering off;
-    proxy_request_buffering off;
-
-    # Extend timeouts for long connections
-    proxy_read_timeout 3600s;
-    proxy_send_timeout 3600s;
-    keepalive_timeout 3600s;
-
-    # Prevent nginx from trying other upstreams
-    proxy_next_upstream off;
 
     # Increase max upload size (required for Tus — without this, uploads over 1 MB fail)
     client_max_body_size 10M;


### PR DESCRIPTION
There were some duplicated configuration options in the nginx sample configuration; they initially led me to think that the whole thing was repeated twice, which meant I skipped two lines essential for avoiding Nginx proxy errors.  I simply deleted the repeated options.