### PR TITLE
admin-docs: add password configuration for writable public links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ pnpm run start --locale de
 > ⚠️ Switching languages via the language switcher is currently not supported.
 
 
-
-
 ## Build
 
 ```bash

--- a/docs/admin/configuration/remove-password-link.md
+++ b/docs/admin/configuration/remove-password-link.md
@@ -18,10 +18,15 @@ Open the environment configuration file located in your `opencloud-compose` dire
 nano opencloud-compose/.env
 ```
 
-Add the following environment variable to disable the password requirement for public links:
+Add the following environment variables to configure password requirements for public links:
 
 ```env
+# Disable password requirement for all public links (read-only and writable)
 OC_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD=false
+
+# Optional: Enforce password only for writable public links
+# Note: This setting only applies when OC_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD is set to false
+OC_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD=true
 ```
 
 ## Restart Docker Services
@@ -35,7 +40,8 @@ docker compose up -d
 
 ## Result
 
-The system no longer enforces a password when creating public share links.
+- **`OC_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD=false`**: The system no longer enforces a password when creating public share links (both read-only and writable).
+- **`OC_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD=true`**: If the first variable is set to `false`, this option allows you to still enforce passwords specifically for writable public shares while keeping read-only shares password-free.
 
 :::note
 This change applies globally to all public shares created after the restart.


### PR DESCRIPTION
related https://github.com/orgs/opencloud-eu/discussions/359#discussioncomment-15270317

added `OC_SHARING_PUBLIC_WRITEABLE_SHARE_MUST_HAVE_PASSWORD` environment variable to public link password configuration guide