### PR TITLE
add https directive for nginx 1.25

### DIFF
--- a/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md
+++ b/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md
@@ -252,6 +252,10 @@ server {
 }
 ```
 
+:::info Version Differences
+Starting from nginx 1.25.0, the `http2` directive syntax changed from: `listen 443 ssl http2;` to `listen 443 ssl; http2 on;`
+:::
+
 :::note
 We enabled HTTP/2 and increased keep-alive limits to prevent large syncs from failing and ensure stable client connections, since nginx closes connections after ~1,000 requests by default.
 :::


### PR DESCRIPTION
I kept the old syntax of the `http2` directive and added a note on how to use it for nginx versions 1.25 and above

<img width="829" height="506" alt="image" src="https://github.com/user-attachments/assets/f0cf3ab0-8dfd-4be5-bbf2-ff3b18f4af71" />
