### PR TITLE
🎉 Release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.6.0](https://github.com/opencloud-eu/docs/releases/tag/3.6.0) - 2026-01-14
+## [3.6.0](https://github.com/opencloud-eu/docs/releases/tag/3.6.0) - 2026-01-15
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -16,6 +16,7 @@
 
 ### 📦️ Build&Tools
 
+- chore: change version name [[#591](https://github.com/opencloud-eu/docs/pull/591)]
 - fix: missing blogDir warning during build [[#588](https://github.com/opencloud-eu/docs/pull/588)]
 - exclude the _static folder for linter and formatter [[#587](https://github.com/opencloud-eu/docs/pull/587)]
 - remove graphviz package installation from CI build [[#579](https://github.com/opencloud-eu/docs/pull/579)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.6.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.6.0](https://github.com/opencloud-eu/docs/releases/tag/3.6.0) - 2026-01-15

### :octocat: Developer Documentation

- Change version folder [[#582](https://github.com/opencloud-eu/docs/pull/582)]

### 👷 Admin Documentation

- add https directive for nginx 1.25 [[#577](https://github.com/opencloud-eu/docs/pull/577)]

### 📦️ Build&Tools

- chore: change version name [[#591](https://github.com/opencloud-eu/docs/pull/591)]
- fix: missing blogDir warning during build [[#588](https://github.com/opencloud-eu/docs/pull/588)]
- exclude the _static folder for linter and formatter [[#587](https://github.com/opencloud-eu/docs/pull/587)]
- remove graphviz package installation from CI build [[#579](https://github.com/opencloud-eu/docs/pull/579)]