### PR TITLE
remove graphviz package installation from CI build

### DIFF
--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -22,7 +22,6 @@ steps:
   - name: build
     image: quay.io/opencloudeu/nodejs-alpine-ci:24
     commands:
-      - apk add --no-cache graphviz graphviz-dev ttf-liberation
       - pnpm install
       - pnpm list likec4
       - pnpm build-likec4


### PR DESCRIPTION
change removes the unnecessary package installation step from the CI build
`nodejs-alpine-ci:24` already includes this
see https://github.com/opencloud-eu/container-ci/pull/29