### PR TITLE
🎉 Release 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.8.2](https://github.com/opencloud-eu/docs/releases/tag/3.8.2) - 2026-01-22
+
+### ❤️ Thanks to all contributors! ❤️
+
+@AlexAndBear
+
+### 📦️ Build&Tools
+
+- fix: links in markdown files that point to a category must have a tra… [[#609](https://github.com/opencloud-eu/docs/pull/609)]
+
 ## [3.8.1](https://github.com/opencloud-eu/docs/releases/tag/3.8.1) - 2026-01-22
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.8.2` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.8.2](https://github.com/opencloud-eu/docs/releases/tag/3.8.2) - 2026-01-22

### 📦️ Build&Tools

- fix: links in markdown files that point to a category must have a tra… [[#609](https://github.com/opencloud-eu/docs/pull/609)]