### PR TITLE
fix: don't show version drop on landing page

### DIFF
--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -15,9 +15,5 @@ export default function DocsVersionDropdownNavbarItemWrapper(props: Props): Reac
     return null;
   }
 
-  return (
-    <>
-      <DocsVersionDropdownNavbarItem {...props} />
-    </>
-  );
+  return <DocsVersionDropdownNavbarItem {...props} />;
 }


### PR DESCRIPTION
The version dropdown was appearing on the landing page (/) where it caused confusing navigation behavior. When users clicked the version selector from the landing page, Docusaurus defaulted to navigating to the Admin docs section, as it had no context about which documentation section (User, Admin, or Dev) the user intended to access.