### PR TITLE
fix: document id add_members resulting in a snake case url instead of kebap case

### DIFF
--- a/docs/user/spaces/add-user.md
+++ b/docs/user/spaces/add-user.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-id: add_members
+id: add-members
 title: Add members
 description: Add new members to your Space in OpenCloud
 draft: false

--- a/i18n/de/docusaurus-plugin-content-docs/current/user/spaces/add-user.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/user/spaces/add-user.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-id: add_members
+id: add-members
 title: Mitglieder hinzufügen
 description: Mitglieder zu Space hinzufügen in OpenCloud
 draft: false

--- a/i18n/de/docusaurus-plugin-content-docs/version-4.0/user/spaces/add-user.md
+++ b/i18n/de/docusaurus-plugin-content-docs/version-4.0/user/spaces/add-user.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-id: add_members
+id: add-members
 title: Mitglieder hinzufügen
 description: Mitglieder zu Space hinzufügen in OpenCloud
 draft: false

--- a/versioned_docs/version-4.0/user/spaces/add-user.md
+++ b/versioned_docs/version-4.0/user/spaces/add-user.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-id: add_members
+id: add-members
 title: Add members
 description: Add new members to your Space in OpenCloud
 draft: false


### PR DESCRIPTION
https://docs.opencloud.eu/docs/next/user/spaces/add_members -> must be https://docs.opencloud.eu/docs/next/user/spaces/add-members