### PR TITLE
🎉 Release 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [3.9.0](https://github.com/opencloud-eu/docs/releases/tag/3.9.0) - 2026-01-23
+
+### ❤️ Thanks to all contributors! ❤️
+
+@AlexAndBear
+
+### 👤 User Documentation
+
+- fix: document id add_members resulting in a snake case url instead of kebap case [[#613](https://github.com/opencloud-eu/docs/pull/613)]
+
+### 📦️ Build&Tools
+
+- feat: docs url on landing page navigates to the selected version [[#612](https://github.com/opencloud-eu/docs/pull/612)]
+
 ## [3.8.2](https://github.com/opencloud-eu/docs/releases/tag/3.8.2) - 2026-01-22
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.9.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.9.0](https://github.com/opencloud-eu/docs/releases/tag/3.9.0) - 2026-01-23

### 👤 User Documentation

- fix: document id add_members resulting in a snake case url instead of kebap case [[#613](https://github.com/opencloud-eu/docs/pull/613)]

### 📦️ Build&Tools

- feat: docs url on landing page navigates to the selected version [[#612](https://github.com/opencloud-eu/docs/pull/612)]