### PR TITLE
🎉 Release 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 📦️ Build&Tools
 
+- chore: move deep nested _static folder to top [[#629](https://github.com/opencloud-eu/docs/pull/629)]
 - Change path for static files [[#622](https://github.com/opencloud-eu/docs/pull/622)]
 - Update docs [[#626](https://github.com/opencloud-eu/docs/pull/626)]
 - Update docs [[#624](https://github.com/opencloud-eu/docs/pull/624)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.10.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.10.0](https://github.com/opencloud-eu/docs/releases/tag/3.10.0) - 2026-01-29

### 👷 Admin Documentation

- publish release note 5.0.0 [[#619](https://github.com/opencloud-eu/docs/pull/619)]

### 📦️ Build&Tools

- chore: move deep nested _static folder to top [[#629](https://github.com/opencloud-eu/docs/pull/629)]
- Change path for static files [[#622](https://github.com/opencloud-eu/docs/pull/622)]
- Update docs [[#626](https://github.com/opencloud-eu/docs/pull/626)]
- Update docs [[#624](https://github.com/opencloud-eu/docs/pull/624)]