### PR TITLE
Update docker-external-proxy.md to fix issue with nginx

### DIFF
--- a/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md
+++ b/docs/admin/getting-started/container/docker-compose/docker-external-proxy.md
@@ -196,7 +196,7 @@ server {
     proxy_send_timeout 3600s;
     keepalive_requests 100000;
     keepalive_timeout 5m;
-    http2_max_concurrent_streams 512;
+    http2_max_concurrent_streams 100;
 
     # Prevent nginx from trying other upstreams
     proxy_next_upstream off;


### PR DESCRIPTION
the nginx config must not allow more concurrent http2 streams than the backend go-proxy in opencloud allowes