### PR TITLE
🎉 Release 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@flimmy
+@ScharfViktor, @flimmy
 
 ### 👷 Admin Documentation
 
+- publish release note rolling-5.0.2, production-4.0.2 and 4.0.3  [[#646](https://github.com/opencloud-eu/docs/pull/646)]
 - Update docker-external-proxy.md to fix issue with nginx [[#643](https://github.com/opencloud-eu/docs/pull/643)]
 
 ## [3.11.0](https://github.com/opencloud-eu/docs/releases/tag/3.11.0) - 2026-02-02


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.12.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.12.0](https://github.com/opencloud-eu/docs/releases/tag/3.12.0) - 2026-02-05

### 👷 Admin Documentation

- publish release note rolling-5.0.2, production-4.0.2 and 4.0.3  [[#646](https://github.com/opencloud-eu/docs/pull/646)]
- Update docker-external-proxy.md to fix issue with nginx [[#643](https://github.com/opencloud-eu/docs/pull/643)]