### PR TITLE
Clarify backchannel logout behavior

### DIFF
--- a/docs/admin/configuration/authentication-and-user-management/keycloak.md
+++ b/docs/admin/configuration/authentication-and-user-management/keycloak.md
@@ -64,10 +64,14 @@ If you need to manually configure the clients in Keycloak:
 
 #### Backchannel Logout
 
-OpenCloud supports Keycloak's backchannel logout feature, which allows Keycloak to notify OpenCloud when a user logs out. This ensures that all sessions are properly terminated:
+OpenCloud supports Keycloak's [backchannel logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) feature, which allows Keycloak to notify OpenCloud when a user logs out.
 
 - Backchannel Logout URL: `https://your-domain.example.com/backchannel_logout`
 - Backchannel Logout Session Required: `true`
+
+:::note
+When a user logs out from one browser or device, all other active web sessions for that user will also be logged out.
+:::
 
 ## Shared User Directory Mode
 


### PR DESCRIPTION
Clarify backchannel logout behavior: when a user logs out from one browser or device, all other active web sessions for that user are also logged out.

The current docs say "ensures that all sessions are properly terminated" which, combined with `Backchannel Logout Session Required: true`, could be read as per-session logout. Per the [OIDC Backchannel Logout spec (Section 2.4)](https://openid.net/specs/openid-connect-backchannel-1_0.html), `session_required: true` means the `sid` claim is included in the logout token, identifying a specific session.

In practice, the [backchannel logout handler](https://github.com/opencloud-eu/opencloud/blob/main/services/proxy/pkg/staticroutes/backchannellogout.go#L36) correctly invalidates only the specific session by `sid`, but the SSE notification that follows broadcasts to all connected clients of that user ([clientlog service](https://github.com/opencloud-eu/opencloud/blob/main/services/clientlog/pkg/service/service.go#L299)), causing all web sessions to log out.

Tested on demo.opencloud.eu: logout in Safari logs out the same user in Chromium.
