### PR TITLE
🎉 Release 3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## [3.12.1](https://github.com/opencloud-eu/docs/releases/tag/3.12.1) - 2026-02-09
+## [3.13.0](https://github.com/opencloud-eu/docs/releases/tag/3.13.0) - 2026-02-12
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@openclouders
+@ScharfViktor, @Svanvith, @openclouders
+
+### 👷 Admin Documentation
+
+- add in the upgrade instruction the opencloud-compose git pull part [[#652](https://github.com/opencloud-eu/docs/pull/652)]
+- publish release note 5.1.0 [[#658](https://github.com/opencloud-eu/docs/pull/658)]
 
 ### 📦️ Build&Tools
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.13.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.13.0](https://github.com/opencloud-eu/docs/releases/tag/3.13.0) - 2026-02-12

### 👷 Admin Documentation

- add in the upgrade instruction the opencloud-compose git pull part [[#652](https://github.com/opencloud-eu/docs/pull/652)]
- publish release note 5.1.0 [[#658](https://github.com/opencloud-eu/docs/pull/658)]

### 📦️ Build&Tools

- Update docs [[#651](https://github.com/opencloud-eu/docs/pull/651)]