### PR TITLE
chore: clarify s3 env variables in config docs

### DIFF
--- a/docs/admin/configuration/storage/decomposeds3.md
+++ b/docs/admin/configuration/storage/decomposeds3.md
@@ -41,6 +41,12 @@ nano .env
 
 Now we need all the information about the S3 bucket we created earlier. Modify the following lines in your `.env` file:
 
+:::tip
+
+The `DECOMPOSEDS3_*` variables used below are specific to [opencloud's docker-compose deployment method](https://github.com/opencloud-eu/opencloud-compose). If deploying outside of the recommended docker-compose configuration, the proper environment variables variables are `STORAGE_USERS_DECOMPOSEDS3_*`. See the [storage-users](../../../dev/server/services/storage-users) documentation for more details.
+
+:::
+
 ```yaml
 # Configure the S3 storage endpoint. Defaults to "http://minio:9000" for testing purposes.
 DECOMPOSEDS3_ENDPOINT=https//your-s3-endpoint.example.com


### PR DESCRIPTION
I spent the better part of a night/morning debugging my s3 server 😄 I believe this is an important tip to have in the docs for anyone unfamiliar with the docs structure and the opencloud-compose repository.

Thanks!!