### PR TITLE
🎉 Release 3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [3.16.1](https://github.com/opencloud-eu/docs/releases/tag/3.16.1) - 2026-03-13
+## [3.17.0](https://github.com/opencloud-eu/docs/releases/tag/3.17.0) - 2026-03-16
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@openclouders
+@kulmann, @openclouders
+
+### :octocat: Developer Documentation
+
+- add new extension points to dev docs [[#709](https://github.com/opencloud-eu/docs/pull/709)]
 
 ### 📦️ Build&Tools
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.17.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.17.0](https://github.com/opencloud-eu/docs/releases/tag/3.17.0) - 2026-03-16

### :octocat: Developer Documentation

- add new extension points to dev docs [[#709](https://github.com/opencloud-eu/docs/pull/709)]

### 📦️ Build&Tools

- Update docs [[#708](https://github.com/opencloud-eu/docs/pull/708)]