### PR TITLE
migration to 6.0.0

### DIFF
--- a/docs/admin/maintenance/upgrade/release-notes.md
+++ b/docs/admin/maintenance/upgrade/release-notes.md
@@ -6,6 +6,29 @@ description: Release Notes
 draft: false
 ---
 
+# Release Notes: Migration from v5.x.x to v6.0.0
+
+- Version: 6.0.0
+- Type: Major Release (Breaking Change in Search Index)
+- [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v6.0.0)
+
+## Who Is Affected?
+
+Users who use the **OpenSearch backend** for search functionality.
+
+## Key Changes
+
+The OpenSearch index has been redesigned with the following improvements:
+- Fixes for persisting and querying favorite information
+- Fast Vector Highlighter support — significantly faster and without the character limits of the previous default highlighter
+
+:::warning breaking change
+This is an incompatible change. Users of the OpenSearch backend will have to drop their old index and rebuild it using:
+```bash
+opencloud search index --all-spaces
+```
+:::
+
 # Release Notes: Migration from v4.x.x to v5.0.0
 
 - Version: 5.0.0

--- a/docs/admin/maintenance/upgrade/release-notes.md
+++ b/docs/admin/maintenance/upgrade/release-notes.md
@@ -19,14 +19,17 @@ Users who use the **OpenSearch backend** for search functionality.
 ## Key Changes
 
 The OpenSearch index has been redesigned with the following improvements:
+
 - Fixes for persisting and querying favorite information
 - Fast Vector Highlighter support — significantly faster and without the character limits of the previous default highlighter
 
 :::warning breaking change
 This is an incompatible change. Users of the OpenSearch backend will have to drop their old index and rebuild it using:
+
 ```bash
 opencloud search index --all-spaces
 ```
+
 :::
 
 # Release Notes: Migration from v4.x.x to v5.0.0

--- a/versioned_docs/version-4.0/admin/maintenance/upgrade/release-notes.md
+++ b/versioned_docs/version-4.0/admin/maintenance/upgrade/release-notes.md
@@ -6,6 +6,50 @@ description: Release Notes
 draft: false
 ---
 
+# Release Notes: Migration from v5.x.x to v6.0.0
+
+- Version: 6.0.0
+- Type: Major Release (Breaking Change in Search Index)
+- [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v6.0.0)
+
+## Who Is Affected?
+
+Users who use the **OpenSearch backend** for search functionality.
+
+## Key Changes
+
+The OpenSearch index has been redesigned with the following improvements:
+
+- Fixes for persisting and querying favorite information
+- Fast Vector Highlighter support — significantly faster and without the character limits of the previous default highlighter
+
+:::warning breaking change
+This is an incompatible change. Users of the OpenSearch backend will have to drop their old index and rebuild it using:
+
+```bash
+opencloud search index --all-spaces
+```
+
+:::
+
+# Release Notes: Migration from v4.x.x to v5.0.0
+
+- Version: 5.0.0
+- Type: Major Release (Breaking Change in Service Architecture)
+- [Details · Download](https://github.com/opencloud-eu/opencloud/releases/tag/v5.0.0)
+
+## Who Is Affected?
+
+If you use the official Docker Compose setup, no migration is typically required.
+
+## Key Changes
+
+The OCDAV is no longer initialized as its own service, it was moved from the backend services into the frontend service
+
+:::compatibility note
+Legacy env variable names (OCDAV\_\*) still work. They just need to be set on the frontend service now
+:::
+
 # Release Notes: Migration from v2.x.x to v3.0.0
 
 - Version: 3.0.0


### PR DESCRIPTION
releated https://github.com/opencloud-eu/opencloud/issues/2540
This PR adds a migration guide for the breaking change introduced in v6.0.0.