### PR TITLE
external-idp.md: add logout redirect URI to web client

### DIFF
--- a/versioned_docs/version-4.0/admin/configuration/authentication-and-user-management/external-idp.md
+++ b/versioned_docs/version-4.0/admin/configuration/authentication-and-user-management/external-idp.md
@@ -157,6 +157,7 @@ The web client is used for browser-based access to OpenCloud:
   - `https://your-domain.example.com/`
   - `https://your-domain.example.com/oidc-callback.html`
   - `https://your-domain.example.com/oidc-silent-redirect.html`
+- Post Logout Redirect URIs: `https://your-domain.example.com/`
 
 ### Desktop Client
 


### PR DESCRIPTION
When clicking signout in OpenCloud, I thought the flow was choppy. My IDP did not redirect me back to OpenCloud to signin again (possibly as a different user). If I wanted to do that, I had to manually navigate the OpenCloud again. I basically just _guessed_ and added my OpenCloud URI as a logout redirect URI in my IDP's client configuration. This worked well. When clicking signout, I end op on my IDP to login to OpenCloud again.