### PR TITLE
Replace 'guest' role with 'user-light' role

### DIFF
--- a/docs/_static/env-vars/proxy_readme.md
+++ b/docs/_static/env-vars/proxy_readme.md
@@ -221,7 +221,7 @@ role_assignment:
               claim_value: mySpaceAdminRole
             - role_name: user
               claim_value: myUserRole
-            - role_name: guest
+            - role_name: user-light
               claim_value: myGuestRole
 ```
 
@@ -250,7 +250,7 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
   claim_value: opencloudSpaceAdmin
 - role_name: user
   claim_value: opencloudUser
-- role_name: guest
+- role_name: user-light
   claim_value: opencloudcloudGuest
 ```
 

--- a/docs/dev/server/configuration/config-system.md
+++ b/docs/dev/server/configuration/config-system.md
@@ -97,7 +97,7 @@ role_assignment:
         claim_value: mySpaceAdminRole
       - role_name: user
         claim_value: myUserRole
-      - role_name: guest
+      - role_name: user-light
         claim_value: myGuestRole
 ```
 

--- a/versioned_docs/version-4.0/admin/configuration/authentication-and-user-management/external-idp.md
+++ b/versioned_docs/version-4.0/admin/configuration/authentication-and-user-management/external-idp.md
@@ -106,7 +106,7 @@ role_assignment:
         claim_value: mySpaceAdminRole
       - role_name: user
         claim_value: myUserRole
-      - role_name: guest
+      - role_name: user-light
         claim_value: myGuestRole
 ```
 
@@ -135,7 +135,7 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
   claim_value: opencloudSpaceAdmin
 - role_name: user
   claim_value: opencloudUser
-- role_name: guest
+- role_name: user-light
   claim_value: opencloudGuest
 ```
 


### PR DESCRIPTION
Fixed old missleading documentation. As seen in https://docs.opencloud.eu/de/docs/dev/server/services/proxy/yaml-config the correct role is `user-light` instead of guest.