### PR TITLE
fix: update copyright year in footer

### DIFF
--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -23,10 +23,6 @@
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/opencloud-eu"
   },
-  "copyright": {
-    "message": "Copyright © 2025 OpenCloud, powered by Heinlein Gruppe",
-    "description": "The footer copyright"
-  },
   "link.item.label.OpenCloud Community": {
     "message": "OpenCloud Community",
     "description": "The label of footer link with label=OpenCloud Community linking to https://opencloud.eu/opencloud-community"

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -23,10 +23,6 @@
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/opencloud-eu"
   },
-  "copyright": {
-    "message": "Copyright © 2025 OpenCloud, powered by Heinlein Gruppe",
-    "description": "The footer copyright"
-  },
   "link.item.label.OpenCloud Community": {
     "message": "OpenCloud Community",
     "description": "The label of footer link with label=OpenCloud Community linking to https://opencloud.eu/opencloud-community"


### PR DESCRIPTION
This PR removes the hard coded copyright year within the page footer.

The default footer and its copyright is configured within the docusaurus configuration file `docusaurus.config.ts` and the year is dynamically set during build time. Unfortunately the i18n files override this value as it also defines `copyright` variables.

As both values for the `en` and `de` translations are the same and not localised anyway, we could use the default which also doesn't require to fix the date every year.

Footer: I don't know whether the i18n files get translated somewhere else and may revert this fix.