### PR TITLE
🎉 Release 3.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.31.0](https://github.com/opencloud-eu/docs/releases/tag/3.31.0) - 2026-06-30
+## [3.31.0](https://github.com/opencloud-eu/docs/releases/tag/3.31.0) - 2026-07-02
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### 👷 Admin Documentation
 
+- change license to subscription [[#1007](https://github.com/opencloud-eu/docs/pull/1007)]
 - Fix/eurooffice community docs [[#997](https://github.com/opencloud-eu/docs/pull/997)]
 - change enterprise license to premium or professional [[#1001](https://github.com/opencloud-eu/docs/pull/1001)]
 - add the release notes to version-7.2 too [[#1000](https://github.com/opencloud-eu/docs/pull/1000)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.31.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.31.0](https://github.com/opencloud-eu/docs/releases/tag/3.31.0) - 2026-07-02

### 👷 Admin Documentation

- change license to subscription [[#1007](https://github.com/opencloud-eu/docs/pull/1007)]
- Fix/eurooffice community docs [[#997](https://github.com/opencloud-eu/docs/pull/997)]
- change enterprise license to premium or professional [[#1001](https://github.com/opencloud-eu/docs/pull/1001)]
- add the release notes to version-7.2 too [[#1000](https://github.com/opencloud-eu/docs/pull/1000)]
- remove the wopi part from the external proxy docs [[#996](https://github.com/opencloud-eu/docs/pull/996)]
- delete wopiserver content [[#995](https://github.com/opencloud-eu/docs/pull/995)]
- Fix typo in LTS explanation in all 3 lifecycle.md [[#990](https://github.com/opencloud-eu/docs/pull/990)]

### 📦️ Build&Tools

- Update docs [[#998](https://github.com/opencloud-eu/docs/pull/998)]