### PR TITLE
🎉 Release 3.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 👤 User Documentation
 
+- add HTTP enabled in logging in iOS App [[#1021](https://github.com/opencloud-eu/docs/pull/1021)]
 - links in index.md in iOS App [[#1020](https://github.com/opencloud-eu/docs/pull/1020)]
 
 ## [3.32.0](https://github.com/opencloud-eu/docs/releases/tag/3.32.0) - 2026-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.33.0](https://github.com/opencloud-eu/docs/releases/tag/3.33.0) - 2026-07-08
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Heiko-Pohl
+
+### 👤 User Documentation
+
+- links in index.md in iOS App [[#1020](https://github.com/opencloud-eu/docs/pull/1020)]
+
 ## [3.32.0](https://github.com/opencloud-eu/docs/releases/tag/3.32.0) - 2026-07-08
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.33.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.33.0](https://github.com/opencloud-eu/docs/releases/tag/3.33.0) - 2026-07-08

### 👤 User Documentation

- add HTTP enabled in logging in iOS App [[#1021](https://github.com/opencloud-eu/docs/pull/1021)]
- links in index.md in iOS App [[#1020](https://github.com/opencloud-eu/docs/pull/1020)]