### PR TITLE
fix(docs): link 'Maintenance Commands' from the 'Maintenance' page

### DIFF
--- a/docs/admin/maintenance/index.md
+++ b/docs/admin/maintenance/index.md
@@ -16,3 +16,4 @@ Use these guides to keep your OpenCloud installation updated, backed up, and man
 - [Migrate](./migrate.md)
 - [Uninstall](./uninstall.md)
 - [Data Export](./dataexport.md)
+- [Maintenance Commands](./maintenance-commands.md)

--- a/docs/admin/maintenance/maintenance-commands.md
+++ b/docs/admin/maintenance/maintenance-commands.md
@@ -30,7 +30,7 @@ docker compose run --rm opencloud opencloud <command>
 
 ## Storage path
 
-The `--basePath` (`-p`) option is required by storage, revision, and trash commands. It must point to the storage provider path as seen from inside the OpenCloud container.
+The `--basepath` (`-p`) option is required by storage, revision, and trash commands. It must point to the storage provider path as seen from inside the OpenCloud container.
 
 For Docker Compose deployments, the default path is usually:
 


### PR DESCRIPTION
* add missing link to the 'Maintenance Commands' page in the list of sub-pages on the 'Maintenance' page in the Admin section
* additionally, fix a typo on the 'Maintenance Commands' page where the `--basepath` command-line option was mistyped as `--basePath`