### PR TITLE
Update rclone configuration instructions

### DIFF
--- a/docs/admin/maintenance/migrate.md
+++ b/docs/admin/maintenance/migrate.md
@@ -133,7 +133,7 @@ rclone obscure <token>
 
 ## Create the rclone Configuration
 
-Edit the rclone configuration file:
+Edit the rclone configuration file and insert your token into the `pass` field:
 
 ```bash
 nano ~/.config/rclone/rclone.conf


### PR DESCRIPTION
Clarified instructions for editing the rclone configuration file.
Due to a request from our hosting colleagues.