### PR TITLE
🎉 Release 3.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Heiko-Pohl, @JammingBen, @v-scharf
+@Heiko-Pohl, @JammingBen, @flimmy, @v-scharf
+
+### 🐾 Guides
+
+- Update rclone configuration instructions [[#1078](https://github.com/opencloud-eu/docs/pull/1078)]
 
 ### 👷 Admin Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
-## [3.38.0](https://github.com/opencloud-eu/docs/releases/tag/3.38.0) - 2026-08-03
+## [3.38.0](https://github.com/opencloud-eu/docs/releases/tag/3.38.0) - 2026-08-04
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@JammingBen
+@Heiko-Pohl, @JammingBen, @v-scharf
 
 ### 👷 Admin Documentation
 
+- add changes from flimmy in migrate.md in version 7.2 [[#1087](https://github.com/opencloud-eu/docs/pull/1087)]
+- publish release notes 7.4.0 [[#1088](https://github.com/opencloud-eu/docs/pull/1088)]
 - Improve app install and config guide [[#1077](https://github.com/opencloud-eu/docs/pull/1077)]
 
 ## [3.37.0](https://github.com/opencloud-eu/docs/releases/tag/3.37.0) - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.38.0](https://github.com/opencloud-eu/docs/releases/tag/3.38.0) - 2026-08-03
+
+### ❤️ Thanks to all contributors! ❤️
+
+@JammingBen
+
+### 👷 Admin Documentation
+
+- Improve app install and config guide [[#1077](https://github.com/opencloud-eu/docs/pull/1077)]
+
 ## [3.37.0](https://github.com/opencloud-eu/docs/releases/tag/3.37.0) - 2026-07-30
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `3.38.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [3.38.0](https://github.com/opencloud-eu/docs/releases/tag/3.38.0) - 2026-08-04

### 🐾 Guides

- Update rclone configuration instructions [[#1078](https://github.com/opencloud-eu/docs/pull/1078)]

### 👷 Admin Documentation

- add changes from flimmy in migrate.md in version 7.2 [[#1087](https://github.com/opencloud-eu/docs/pull/1087)]
- publish release notes 7.4.0 [[#1088](https://github.com/opencloud-eu/docs/pull/1088)]
- Improve app install and config guide [[#1077](https://github.com/opencloud-eu/docs/pull/1077)]